### PR TITLE
Add link pseudoclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ import { Block } from 'jsxstyle/preact';
 <!-- prettier-ignore -->
 | Supported Pseudoclasses | Supported Pseudoelements |
 | -- | -- |
-| `active`, `checked`, `disabled`, `empty`, `enabled`, `focus`, `hover`, `invalid`, `required`, `target`, `valid` | `placeholder`, `selection`, `before`, `after` |
+| `link`, `active`, `checked`, `disabled`, `empty`, `enabled`, `focus`, `hover`, `invalid`, `required`, `target`, `valid` | `placeholder`, `selection`, `before`, `after` |
 
 <br>
 

--- a/packages/jsxstyle-utils/src/getStyleKeysForProps.ts
+++ b/packages/jsxstyle-utils/src/getStyleKeysForProps.ts
@@ -24,6 +24,7 @@ export const pseudoclasses = {
   required: true,
   target: true,
   valid: true,
+  link: true
 };
 
 const specialCaseProps = {

--- a/packages/jsxstyle/README.md
+++ b/packages/jsxstyle/README.md
@@ -103,7 +103,7 @@ import { Block } from 'jsxstyle/preact';
 <!-- prettier-ignore -->
 | Supported Pseudoclasses | Supported Pseudoelements |
 | -- | -- |
-| `active`, `checked`, `disabled`, `empty`, `enabled`, `focus`, `hover`, `invalid`, `required`, `target`, `valid` | `placeholder`, `selection`, `before`, `after` |
+| `link`, `active`, `checked`, `disabled`, `empty`, `enabled`, `focus`, `hover`, `invalid`, `required`, `target`, `valid` | `placeholder`, `selection`, `before`, `after` |
 
 <br>
 


### PR DESCRIPTION
I happened to have this global css:

```
a:link { color: #03c;}
```
And want to override it with `linkColor` in one of my component:

```
<Inline
      props={{ to: '/' }}
      component={Link}
      color='#4a4a4a'
      fontSize='1.618em'
      lineHeight='2.625em'
      textDecoration='none'
      linkColor='#4a4a4a'
    >
      {props.title}
    </Inline>
```
But found that `link` is not supported in the list https://github.com/smyte/jsxstyle#pseudoelements-and-pseudoclasses, this pull request should support it then.

Or maybe any problems stopping it?