### PR TITLE
Update schema

### DIFF
--- a/packages/jsxstyle-webpack-plugin/schema/loader.json
+++ b/packages/jsxstyle-webpack-plugin/schema/loader.json
@@ -28,7 +28,7 @@
       "description": "array of plugins that should be passed to @babel/parser. You can see a full list of available plugins here: https://new.babeljs.io/docs/en/next/babel-parser.html#plugins",
       "type": "array",
       "items": {
-        "type": "string"
+        "type": ["string", "array"]
       }
     },
     "liteMode": {


### PR DESCRIPTION
Right now we can only use `string` value for [`parserPlugins`](https://github.com/jsxstyle/jsxstyle/tree/master/packages/jsxstyle-webpack-plugin#parserplugins), that means we can't pass any plugin options like this:

```js
{
            loader: JsxstylePlugin.loader,
            options: {
              parserPlugins: [
                ['pipelineOperator', { 'proposal': 'minimal' }]
              ]
            }
          }
```
It will cause error:

> Module Error (from ./node_modules/jsxstyle-webpack-plugin/lib/loader.js):
> jsxstyle-webpack-plugin is incorrectly configured:
>  - options.parserPlugins[0] should be string

This pull request should fix it.