### PR TITLE
Convert jsxstyle factory function to output FCs

### DIFF
--- a/tests/jsxstyle/__snapshots__/typescript.spec.ts.snap
+++ b/tests/jsxstyle/__snapshots__/typescript.spec.ts.snap
@@ -1,9 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`throws type errors for invalid component/prop types 1`] = `
-"jsxstyle/typescript/demo.tsx(14,51): error TS2322: Type '{ value: string; typeError: boolean; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>'.
+"jsxstyle/typescript/demo.tsx(18,51): error TS2322: Type '{ value: string; typeError: boolean; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>'.
   Object literal may only specify known properties, and 'typeError' does not exist in type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>'.
-jsxstyle/typescript/demo.tsx(20,39): error TS2322: Type 'true' is not assignable to type 'never'.
-jsxstyle/typescript/demo.tsx(24,50): error TS2322: Type 'true' is not assignable to type 'never'.
+jsxstyle/typescript/demo.tsx(23,21): error TS2322: Type '{ typeError: boolean; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>'.
+  Object literal may only specify known properties, and 'typeError' does not exist in type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>'.
+jsxstyle/typescript/demo.tsx(24,21): error TS2322: Type 'string' is not assignable to type 'number'.
+jsxstyle/typescript/demo.tsx(30,40): error TS2322: Type '{ typeError: boolean; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DemoProps'.
+  Object literal may only specify known properties, and 'typeError' does not exist in type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DemoProps'.
+jsxstyle/typescript/demo.tsx(33,40): error TS2322: Type 'string' is not assignable to type 'boolean'.
+jsxstyle/typescript/demo.tsx(38,50): error TS2322: Type '{ typeError: boolean; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DemoProps'.
+  Object literal may only specify known properties, and 'typeError' does not exist in type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DemoProps'.
 "
 `;

--- a/tests/jsxstyle/typescript/demo.tsx
+++ b/tests/jsxstyle/typescript/demo.tsx
@@ -2,9 +2,13 @@ import * as React from 'react';
 
 import { Block } from '../../../packages/jsxstyle';
 
-const DemoSFC: React.SFC = (props) => <div {...props} />;
+interface DemoProps {
+  demoProp?: boolean;
+}
 
-class DemoClassComponent extends React.Component {
+const DemoFC: React.FC<DemoProps> = (props) => <div {...props} />;
+
+class DemoClassComponent extends React.Component<DemoProps> {
   public render() {
     return null;
   }
@@ -14,10 +18,20 @@ export const ValidInputComponent = () => (
   <Block component="input" props={{ value: 'wow', typeError: true }} />
 );
 
-export const ImplicitDivComponent = () => <Block props={{ typeError: true }} />;
+export const ImplicitDivComponent = () => (
+  <>
+    <Block props={{ typeError: true }} />
+    <Block props={{ tabIndex: 'type error' }} />
+  </>
+);
 
-export const SFCWithoutProps = () => (
-  <Block component={DemoSFC} props={{ typeError: true }} />
+export const FCWithoutProps = () => (
+  <>
+    <Block component={DemoFC} props={{ typeError: true }} />
+    {/* not a type error, just a sanity check */}
+    <Block component={DemoFC} props={{ demoProp: true }} />
+    <Block component={DemoFC} props={{ demoProp: 'invalid' }} />
+  </>
 );
 
 export const ClassComponentWithoutProps = () => (


### PR DESCRIPTION
This PR does a three things:

1. The jsxstyle factory function now outputs function components. There was really no need to continue using class components. This should have no effect on library consumers.
2. More importantly, the type for `component` now explicitly defaults to `"div"` rather than relying on mostly-function typing shenanigans. This _greatly_ improves type checking and error output for jsxstyle components that don’t have a `component` prop value set.
  
    Before: 
    ![Screenshot 2020-04-03 at 19 39 05](https://user-images.githubusercontent.com/13781/78417024-d4b65800-75e2-11ea-802d-cb66e6522561.png)
  
    After:
    ![Screenshot 2020-04-03 at 19 37 57](https://user-images.githubusercontent.com/13781/78417026-dd0e9300-75e2-11ea-8381-fd9929af851d.png)

  
3. Last but not least, this PR shaves off about 300 bytes of output code after GZIP. That’s about a 10% reduction in size. Some of that savings comes from the now-removed class boilerplate that was introduced in the transpilation process, but funny enough, most of that savings is due to a change in how the `depFactory` is defined.