### PR TITLE
Fix style prop definition, update TypeScript

### DIFF
--- a/examples/jsxstyle-preact-cli-typescript-example/package.json
+++ b/examples/jsxstyle-preact-cli-typescript-example/package.json
@@ -13,6 +13,6 @@
     "ejs-loader": "^0.3.5",
     "preact-cli": "^3.0.0-0",
     "ts-loader": "^6.0.4",
-    "typescript": "~3.8.3"
+    "typescript": "~3.9.6"
   }
 }

--- a/examples/jsxstyle-typescript-example/package.json
+++ b/examples/jsxstyle-typescript-example/package.json
@@ -16,7 +16,7 @@
     "react-dom": "^16.12.0",
     "style-loader": "^1.0.0",
     "ts-loader": "^6.0.4",
-    "typescript": "~3.8.3",
+    "typescript": "~3.9.6",
     "url-loader": "^4.0.0",
     "webpack": "^4.36.1",
     "webpack-cli": "^3.3.6",

--- a/examples/jsxstyle-typescript-example/src/App.tsx
+++ b/examples/jsxstyle-typescript-example/src/App.tsx
@@ -10,10 +10,10 @@ const height = () => 150;
 
 interface LogoProps {
   width: number;
-  height: number;
+  height?: number;
 }
 
-const Logo: React.SFC<LogoProps> = (props) => (
+const Logo: React.FC<LogoProps> = (props) => (
   <InlineBlock
     component="img"
     props={{ src: logo, alt: 'logo' }}

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "tslint": "^6.1.0",
     "tslint-config-prettier": "^1.18.0",
     "tslint-react": "^4.1.0",
-    "typescript": "~3.8.3"
+    "typescript": "~3.9.6"
   },
   "prettier": {
     "singleQuote": true

--- a/packages/jsxstyle-webpack-plugin/src/utils/ast/extractStaticTernaries.ts
+++ b/packages/jsxstyle-webpack-plugin/src/utils/ast/extractStaticTernaries.ts
@@ -9,7 +9,7 @@ import { StylesByClassName } from '../getStylesByClassName';
 
 export interface Ternary {
   name: string;
-  test: t.Expression;
+  test: t.Expression | t.ExpressionStatement;
   consequent: string | null;
   alternate: string | null;
 }

--- a/packages/jsxstyle/src/jsxstyle.tsx
+++ b/packages/jsxstyle/src/jsxstyle.tsx
@@ -48,22 +48,24 @@ export { CSSProperties };
 export const cache = getStyleCache();
 
 /** Props that will be passed through to whatever component is specified */
-export interface StylableComponentProps {
+export interface StylableComponentProps<T extends ValidComponentPropValue> {
   /** passed as-is through to the underlying component */
   className?: string | null | false;
   /** passed as-is through to the underlying component */
-  style?: React.CSSProperties | null | false;
+  style?: ExtractProps<T>['style'] | null | false;
 }
 
 /** Common props */
-interface SharedProps extends StylableComponentProps, CSSProperties {
+interface SharedProps<T extends ValidComponentPropValue>
+  extends StylableComponentProps<T>,
+    CSSProperties {
   /** An object of media query values keyed by the desired style prop prefix */
   mediaQueries?: Record<string, string>;
 }
 
 /** Props for jsxstyle components that have a `component` prop set */
 interface JsxstylePropsWithComponent<C extends ValidComponentPropValue>
-  extends SharedProps {
+  extends SharedProps<C> {
   /** Component value can be either a React component or a tag name string. Defaults to `div`. */
   component: C;
   /** Object of props that will be passed down to the component specified in the `component` prop */
@@ -71,7 +73,7 @@ interface JsxstylePropsWithComponent<C extends ValidComponentPropValue>
 }
 
 /** Props for jsxstyle components that have no `component` prop set */
-interface JsxstyleDefaultProps extends SharedProps {
+interface JsxstyleDefaultProps extends SharedProps<'div'> {
   /** Component value can be either a React component or a tag name string. Defaults to `div`. */
   component?: undefined;
   /** Object of props that will be passed down to the underlying div */

--- a/tests/jsxstyle-webpack-plugin/__snapshots__/extractStyles.spec.ts.snap
+++ b/tests/jsxstyle-webpack-plugin/__snapshots__/extractStyles.spec.ts.snap
@@ -7,7 +7,7 @@ export interface ThingProps {
   thing1: string;
   thing2?: boolean;
 }
-export const Thing: React.SFC<ThingProps> = props => <div className=\\"_x0\\" />;
+export const Thing: React.FC<ThingProps> = props => <div className=\\"_x0\\" />;
 ReactDOM.render(<Thing />, (document.getElementById('root') as HTMLElement));"
 `;
 
@@ -18,7 +18,7 @@ export interface ThingProps {
   thing1: string;
   thing2?: boolean;
 }
-export const Thing: React.SFC<ThingProps> = props => <div className=\\"_x0\\" />;
+export const Thing: React.FC<ThingProps> = props => <div className=\\"_x0\\" />;
 ReactDOM.render(<Thing />, (document.getElementById('root') as HTMLElement));"
 `;
 

--- a/tests/jsxstyle-webpack-plugin/extractStyles.spec.ts
+++ b/tests/jsxstyle-webpack-plugin/extractStyles.spec.ts
@@ -774,7 +774,7 @@ export interface ThingProps {
   thing1: string;
   thing2?: boolean;
 }
-export const Thing: React.SFC<ThingProps> = props => <Block />;
+export const Thing: React.FC<ThingProps> = props => <Block />;
 ReactDOM.render(<Thing />, (document.getElementById('root') as HTMLElement));`;
 
     const tsResults = extractStyles(src, pathTo('mock/typescript.ts'), {

--- a/tests/jsxstyle-webpack-plugin/parse.spec.ts
+++ b/tests/jsxstyle-webpack-plugin/parse.spec.ts
@@ -14,7 +14,7 @@ export interface ThingProps {
   thing1: string;
   thing2?: boolean;
 }
-export const Thing: React.SFC<ThingProps> = props => <Block />;
+export const Thing: React.FC<ThingProps> = props => <Block />;
 ReactDOM.render(<Thing />, (document.getElementById('root') as HTMLElement));`;
 
   expect(p(code, 'typescript')).toEqual(code);

--- a/tests/jsxstyle/typescript.spec.ts
+++ b/tests/jsxstyle/typescript.spec.ts
@@ -21,19 +21,5 @@ const typecheckFiles = (filenames: string[]): string => {
 it('throws type errors for invalid component/prop types', () => {
   const demoFile = path.resolve(__dirname, './typescript/demo.tsx');
   const report = typecheckFiles([demoFile]);
-  expect(report).toMatchInlineSnapshot(`
-    "jsxstyle/typescript/demo.tsx(18,51): error TS2322: Type '{ value: string; typeError: boolean; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>'.
-      Object literal may only specify known properties, and 'typeError' does not exist in type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DetailedHTMLProps<InputHTMLAttributes<HTMLInputElement>, HTMLInputElement>'.
-    jsxstyle/typescript/demo.tsx(23,21): error TS2322: Type '{ typeError: boolean; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>'.
-      Object literal may only specify known properties, and 'typeError' does not exist in type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement>'.
-    jsxstyle/typescript/demo.tsx(24,21): error TS2322: Type 'string' is not assignable to type 'number'.
-    jsxstyle/typescript/demo.tsx(30,40): error TS2322: Type '{ typeError: boolean; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DemoProps'.
-      Object literal may only specify known properties, and 'typeError' does not exist in type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DemoProps'.
-    jsxstyle/typescript/demo.tsx(33,40): error TS2322: Type 'string' is not assignable to type 'boolean'.
-    jsxstyle/typescript/demo.tsx(38,50): error TS2322: Type '{ typeError: boolean; }' is not assignable to type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DemoProps'.
-      Object literal may only specify known properties, and 'typeError' does not exist in type 'DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> | DemoProps'.
-    jsxstyle/typescript/demo.tsx(45,25): error TS2322: Type '{ opacity: number; paddingH: number; }' is not assignable to type 'Properties<string | number>'.
-      Object literal may only specify known properties, but 'paddingH' does not exist in type 'Properties<string | number>'. Did you mean to write 'padding'?
-    "
-  `);
+  expect(report).toMatchInlineSnapshot(`""`);
 });

--- a/tests/jsxstyle/typescript/demo.tsx
+++ b/tests/jsxstyle/typescript/demo.tsx
@@ -8,6 +8,22 @@ interface DemoProps {
 
 const DemoFC: React.FC<DemoProps> = (props) => <div {...props} />;
 
+interface StyleNumberProps {
+  style: number;
+}
+
+const StyleNumberFC: React.FC<StyleNumberProps> = () => null;
+
+interface StyleNeverProps {
+  style: never;
+}
+
+const StyleNeverFC: React.FC<StyleNeverProps> = () => null;
+
+interface NoStyleProps {}
+
+const NoStyleFC: React.FC<NoStyleProps> = () => null;
+
 class DemoClassComponent extends React.Component<DemoProps> {
   public render() {
     return null;
@@ -15,34 +31,91 @@ class DemoClassComponent extends React.Component<DemoProps> {
 }
 
 export const ValidInputComponent = () => (
-  <Block component="input" props={{ value: 'wow', typeError: true }} />
+  <Block
+    component="input"
+    props={{
+      value: 'wow',
+      // @ts-expect-error
+      typeError: true,
+    }}
+  />
 );
 
 export const ImplicitDivComponent = () => (
   <>
-    <Block props={{ typeError: true }} />
-    <Block props={{ tabIndex: 'type error' }} />
+    <Block
+      props={{
+        // @ts-expect-error
+        typeError: true,
+      }}
+    />
+    <Block
+      props={{
+        // @ts-expect-error
+        tabIndex: 'type error',
+      }}
+    />
   </>
 );
 
 export const FCWithoutProps = () => (
   <>
-    <Block component={DemoFC} props={{ typeError: true }} />
-    {/* not a type error, just a sanity check */}
+    <Block
+      component={DemoFC}
+      props={{
+        // @ts-expect-error
+        typeError: true,
+      }}
+    />
     <Block component={DemoFC} props={{ demoProp: true }} />
-    <Block component={DemoFC} props={{ demoProp: 'invalid' }} />
+    <Block
+      component={DemoFC}
+      props={{
+        // @ts-expect-error
+        demoProp: 'invalid',
+      }}
+    />
+  </>
+);
+
+export const FCWithStyleProps = () => (
+  <>
+    <Block component={StyleNumberFC} style={1234} />
+    {/* @ts-expect-error */}
+    <Block component={StyleNumberFC} style={{ width: 1234 }} />
+    {React.createElement(Block, { component: StyleNumberFC, style: 'banana' })}
+    <Block
+      component={StyleNeverFC}
+      // @ts-expect-error
+      style={1234}
+    />
+    <Block
+      component={NoStyleFC}
+      // ideally this would be a type error
+      style="hmmmm"
+    />
   </>
 );
 
 export const ClassComponentWithoutProps = () => (
-  <Block component={DemoClassComponent} props={{ typeError: true }} />
+  <Block
+    component={DemoClassComponent}
+    props={{
+      // @ts-expect-error
+      typeError: true,
+    }}
+  />
 );
 
 export const ComponentWithAnimation: React.FC = () => (
   <Block
     animation={{
       from: { opacity: 0 },
-      to: { opacity: 1, paddingH: 123 },
+      to: {
+        opacity: 1,
+        // @ts-expect-error
+        paddingH: 123,
+      },
     }}
     paddingH={30}
     paddingV={60}

--- a/tests/package.json
+++ b/tests/package.json
@@ -39,7 +39,7 @@
     "terser": "^4.6.11",
     "ts-jest": "^25.2.1",
     "ts-loader": "^6.0.4",
-    "typescript": "~3.8.3",
+    "typescript": "~3.9.6",
     "webpack": "^4.36.1"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15107,10 +15107,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.4.5, typescript@~3.8.3:
+typescript@^3.4.5:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
   integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+
+typescript@~3.9.6:
+  version "3.9.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
+  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
 
 ua-parser-js@^0.7.18:
   version "0.7.21"


### PR DESCRIPTION
The type of the style prop is now set to `(typeof props.component)['style']` rather than naively set to `React.CSSProperties`. I also updated TypeScript to latest (3.9.6) and started using `// @ts-expect-error` in tests.