### PR TITLE
Add key prop to JsxstyleProps

### DIFF
--- a/.changeset/little-radios-thank.md
+++ b/.changeset/little-radios-thank.md
@@ -2,4 +2,4 @@
 'jsxstyle': patch
 ---
 
-Added `key` prop to jsxstyle/preact's JsxstyleProps
+Add `key` prop to jsxstyle/preact's JsxstyleProps

--- a/.changeset/little-radios-thank.md
+++ b/.changeset/little-radios-thank.md
@@ -1,0 +1,5 @@
+---
+'jsxstyle': patch
+---
+
+Added `key` prop to jsxstyle/preact's JsxstyleProps

--- a/.changeset/little-radios-thank.md
+++ b/.changeset/little-radios-thank.md
@@ -2,4 +2,4 @@
 'jsxstyle': patch
 ---
 
-Add `key` prop to jsxstyle/preact's JsxstyleProps
+Added a `key` prop to the `JsxstyleProps` interface in `jsxstyle/preact`

--- a/packages/jsxstyle/preact/src/index.tsx
+++ b/packages/jsxstyle/preact/src/index.tsx
@@ -32,6 +32,8 @@ export interface JsxstyleProps<ComponentProps>
   mediaQueries?: Record<string, string>;
   /** Object of props that will be passed down to the component specified in the `component` prop */
   props?: ComponentProps;
+  /** Used by Preact to keep track of which components represent which DOM nodes */
+  key?: preact.Key;
 }
 
 type JsxstyleComponent = preact.ComponentConstructor<


### PR DESCRIPTION
Avoids `property 'key' does not exist on JsxstyleProps<{}>` error when creating custom components like:

```ts
function MyBlock(props: JsxstyleProps<{}>) {
  return (
    <Block
      { ...props }
      // my custom props
    />
  );
}
```