### PR TITLE
Allow common component props to be set at the top level

### DIFF
--- a/.changeset/breaking style cache change.md
+++ b/.changeset/breaking style cache change.md
@@ -1,0 +1,5 @@
+---
+'jsxstyle-utils': major
+---
+
+Remove `getClassName` method from style cache, add `getComponentProps` method that returns a filtered object of component props.

--- a/.changeset/component prop allowlist.md
+++ b/.changeset/component prop allowlist.md
@@ -1,0 +1,5 @@
+---
+'jsxstyle': minor
+---
+
+Allow a few common props (`type`, `name`, and a few other) to be set at the top level of a jsxstyle component as well as being set in the props prop. This should make styling and configuring commonly-used components a bit less painful. For additional context, see #147.

--- a/packages/jsxstyle-utils/src/__tests__/getStyleKeysForProps.spec.ts
+++ b/packages/jsxstyle-utils/src/__tests__/getStyleKeysForProps.spec.ts
@@ -2,7 +2,7 @@ import { getStyleKeysForProps } from '..';
 
 describe('getStyleKeysForProps', () => {
   it('returns null when given an empty style object', () => {
-    const keyObj = getStyleKeysForProps({});
+    const keyObj = getStyleKeysForProps({}, 'className');
     expect(keyObj).toBeNull();
   });
 
@@ -28,24 +28,26 @@ describe('getStyleKeysForProps', () => {
         prop6: undefined,
         prop7: false,
       },
+      'className',
       true
     );
 
     expect(keyObj).toMatchInlineSnapshot(`
-      Object {
-        "classNameKey": "prop1:string;prop2:1234px;prop3:0;prop4:wow;",
-        "stylesByKey": Object {
-          ".": Object {
-            "styles": "
-        prop1: string;
-        prop2: 1234px;
-        prop3: 0;
-        prop4: wow;
-      ",
-          },
-        },
-      }
-    `);
+Object {
+  "classNameKey": "prop1:string;prop2:1234px;prop3:0;prop4:wow;",
+  "props": null,
+  "stylesByKey": Object {
+    ".": Object {
+      "styles": "
+  prop1: string;
+  prop2: 1234px;
+  prop3: 0;
+  prop4: wow;
+",
+    },
+  },
+}
+`);
   });
 
   it('splits out pseudoelements and pseudoclasses', () => {
@@ -56,42 +58,46 @@ describe('getStyleKeysForProps', () => {
         placeholderColor: 'blue',
         selectionBackgroundColor: 'red',
       },
+      'className',
       false
     );
 
     expect(keyObj).toMatchInlineSnapshot(`
-      Object {
-        "classNameKey": "activeColor:purple;hoverColor:orange;placeholderColor:blue;selectionBackgroundColor:red;",
-        "stylesByKey": Object {
-          ".::placeholder": Object {
-            "pseudoelement": "placeholder",
-            "styles": "color:blue;",
-          },
-          ".::selection": Object {
-            "pseudoelement": "selection",
-            "styles": "background-color:red;",
-          },
-          ".:active": Object {
-            "pseudoclass": "active",
-            "styles": "color:purple;",
-          },
-          ".:hover": Object {
-            "pseudoclass": "hover",
-            "styles": "color:orange;",
-          },
-        },
-      }
-    `);
+Object {
+  "classNameKey": "activeColor:purple;hoverColor:orange;placeholderColor:blue;selectionBackgroundColor:red;",
+  "props": null,
+  "stylesByKey": Object {
+    ".::placeholder": Object {
+      "pseudoelement": "placeholder",
+      "styles": "color:blue;",
+    },
+    ".::selection": Object {
+      "pseudoelement": "selection",
+      "styles": "background-color:red;",
+    },
+    ".:active": Object {
+      "pseudoclass": "active",
+      "styles": "color:purple;",
+    },
+    ".:hover": Object {
+      "pseudoclass": "hover",
+      "styles": "color:orange;",
+    },
+  },
+}
+`);
   });
 
   it('generates identical classNameKeys for identical styles objects', () => {
     const keyObj1 = getStyleKeysForProps(
       { color: 'red', fooColor: 'blue', mediaQueries: { foo: 'test mq' } },
+      'className',
       false
     );
 
     const keyObj2 = getStyleKeysForProps(
       { color: 'red', barColor: 'blue', mediaQueries: { bar: 'test mq' } },
+      'className',
       false
     );
 
@@ -102,11 +108,13 @@ describe('getStyleKeysForProps', () => {
   it('generates different classNameKeys for styles objects with different content', () => {
     const keyObj1 = getStyleKeysForProps(
       { color: 'red', fooColor: 'blue', mediaQueries: { foo: 'test mq1' } },
+      'className',
       false
     );
 
     const keyObj2 = getStyleKeysForProps(
       { color: 'red', fooColor: 'blue', mediaQueries: { foo: 'test mq2' } },
+      'className',
       false
     );
 
@@ -115,13 +123,16 @@ describe('getStyleKeysForProps', () => {
   });
 
   it('expands horizontal/vertical margin/padding shorthand props', () => {
-    const keyObj1 = getStyleKeysForProps({
-      aaa: 123,
-      zzz: 123,
-      margin: 1, // least specific
-      marginH: 2, // expands to marginLeft + marginRight
-      marginLeft: 3, // most specific
-    });
+    const keyObj1 = getStyleKeysForProps(
+      {
+        aaa: 123,
+        zzz: 123,
+        margin: 1, // least specific
+        marginH: 2, // expands to marginLeft + marginRight
+        marginLeft: 3, // most specific
+      },
+      'className'
+    );
 
     expect(keyObj1?.classNameKey).toEqual(
       'aaa:123px;margin:1px;marginH:2px;marginLeft:3px;zzz:123px;'
@@ -129,40 +140,44 @@ describe('getStyleKeysForProps', () => {
   });
 
   it('supports pseudo-prefixed horizontal/vertical margin/padding shorthand props', () => {
-    const keyObj1 = getStyleKeysForProps({
-      mediaQueries: { sm: 'test' },
-      margin: 1,
-      marginH: 2,
-      marginLeft: 3,
-      // unsupported
-      hoverMarginLeft: 4,
-      activeMarginV: 5,
-      // should be supported
-      smMarginH: 6,
-    });
+    const keyObj1 = getStyleKeysForProps(
+      {
+        mediaQueries: { sm: 'test' },
+        margin: 1,
+        marginH: 2,
+        marginLeft: 3,
+        // unsupported
+        hoverMarginLeft: 4,
+        activeMarginV: 5,
+        // should be supported
+        smMarginH: 6,
+      },
+      'className'
+    );
 
     expect(keyObj1).toMatchInlineSnapshot(`
-      Object {
-        "classNameKey": "activeMarginV:5px;hoverMarginLeft:4px;margin:1px;marginH:2px;marginLeft:3px;@test~marginH:6px;",
-        "stylesByKey": Object {
-          ".": Object {
-            "styles": "margin:1px;margin-left:2px;margin-right:2px;margin-left:3px;",
-          },
-          ".:active": Object {
-            "pseudoclass": "active",
-            "styles": "margin-top:5px;margin-bottom:5px;",
-          },
-          ".:hover": Object {
-            "pseudoclass": "hover",
-            "styles": "margin-left:4px;",
-          },
-          ".@1000": Object {
-            "mediaQuery": "test",
-            "styles": "margin-left:6px;margin-right:6px;",
-          },
-        },
-      }
-    `);
+Object {
+  "classNameKey": "activeMarginV:5px;hoverMarginLeft:4px;margin:1px;marginH:2px;marginLeft:3px;@test~marginH:6px;",
+  "props": null,
+  "stylesByKey": Object {
+    ".": Object {
+      "styles": "margin:1px;margin-left:2px;margin-right:2px;margin-left:3px;",
+    },
+    ".:active": Object {
+      "pseudoclass": "active",
+      "styles": "margin-top:5px;margin-bottom:5px;",
+    },
+    ".:hover": Object {
+      "pseudoclass": "hover",
+      "styles": "margin-left:4px;",
+    },
+    ".@1000": Object {
+      "mediaQuery": "test",
+      "styles": "margin-left:6px;margin-right:6px;",
+    },
+  },
+}
+`);
   });
 
   it.skip('generates identical classNameKeys for style objects with duplicate media queries', () => {
@@ -170,11 +185,13 @@ describe('getStyleKeysForProps', () => {
 
     const keyObj1 = getStyleKeysForProps(
       { fooProp1: 'blue', barProp2: 'red', mediaQueries },
+      'className',
       false
     );
 
     const keyObj2 = getStyleKeysForProps(
       { barProp1: 'blue', fooProp2: 'red', mediaQueries },
+      'className',
       false
     );
 
@@ -191,45 +208,47 @@ describe('getStyleKeysForProps', () => {
       },
     };
 
-    const keyObj1 = getStyleKeysForProps(styleObj, true);
-    const keyObj2 = getStyleKeysForProps(styleObj, false);
+    const keyObj1 = getStyleKeysForProps(styleObj, 'className', true);
+    const keyObj2 = getStyleKeysForProps(styleObj, 'className', false);
 
     expect(keyObj1).toMatchInlineSnapshot(`
-      Object {
-        "animations": Object {
-          "jsxstyle_14kipeq": "
-      from {
-        opacity: 0;
-      }
-      to {
-        padding: 123px;
-      }
-      ",
-        },
-        "classNameKey": "animation:jsxstyle_14kipeq;color:red;",
-        "stylesByKey": Object {
-          ".": Object {
-            "styles": "
-        animation-name: jsxstyle_14kipeq;
-        color: red;
-      ",
-          },
-        },
-      }
-    `);
+Object {
+  "animations": Object {
+    "jsxstyle_14kipeq": "
+from {
+  opacity: 0;
+}
+to {
+  padding: 123px;
+}
+",
+  },
+  "classNameKey": "animation:jsxstyle_14kipeq;color:red;",
+  "props": null,
+  "stylesByKey": Object {
+    ".": Object {
+      "styles": "
+  animation-name: jsxstyle_14kipeq;
+  color: red;
+",
+    },
+  },
+}
+`);
 
     expect(keyObj2).toMatchInlineSnapshot(`
-      Object {
-        "animations": Object {
-          "jsxstyle_q1qr48": "from{opacity:0;}to{padding:123px;}",
-        },
-        "classNameKey": "animation:jsxstyle_q1qr48;color:red;",
-        "stylesByKey": Object {
-          ".": Object {
-            "styles": "animation-name:jsxstyle_q1qr48;color:red;",
-          },
-        },
-      }
-    `);
+Object {
+  "animations": Object {
+    "jsxstyle_q1qr48": "from{opacity:0;}to{padding:123px;}",
+  },
+  "classNameKey": "animation:jsxstyle_q1qr48;color:red;",
+  "props": null,
+  "stylesByKey": Object {
+    ".": Object {
+      "styles": "animation-name:jsxstyle_q1qr48;color:red;",
+    },
+  },
+}
+`);
   });
 });

--- a/packages/jsxstyle-utils/src/__tests__/react.karma.tsx
+++ b/packages/jsxstyle-utils/src/__tests__/react.karma.tsx
@@ -29,7 +29,8 @@ describe('jsxstyle', () => {
           <Row>
             <Block
               component="a"
-              props={{ id, href: '#wow' }}
+              href="#wow"
+              id={id}
               color="blue"
               placeholderColor="red"
               hoverColor="orange"
@@ -47,7 +48,12 @@ describe('jsxstyle', () => {
         node,
         () => {
           const item = document.getElementById(id);
+          if (!item) {
+            throw new Error('Could not find an element with ID `' + id + '`');
+          }
           expect(item.getAttribute('class')).toEqual('_1fc5o');
+          expect(item.getAttribute('href')).toEqual('#wow');
+          expect(item.children.length).toEqual(1);
 
           const style = window.getComputedStyle(item);
           const styleObj: Record<string, string> = {};

--- a/packages/jsxstyle-utils/src/getStyleCache.ts
+++ b/packages/jsxstyle-utils/src/getStyleCache.ts
@@ -55,15 +55,15 @@ export function getStyleCache() {
       styleCache.injectOptions = alreadyInjected;
     },
 
-    getClassName(
+    getComponentProps(
       props: Record<string, any>,
-      classNameProp?: string | null | false
-    ): string | null {
+      classNamePropKey = 'className'
+    ): Record<string, any> | null {
       styleCache.injectOptions = cannotInject;
 
-      const styleObj = getStyleKeysForProps(props, pretty);
+      const styleObj = getStyleKeysForProps(props, classNamePropKey, pretty);
       if (styleObj == null) {
-        return classNameProp || null;
+        return null;
       }
 
       const key = styleObj.classNameKey;
@@ -107,9 +107,21 @@ export function getStyleCache() {
         }
       }
 
-      return _classNameCache[key] && classNameProp
-        ? classNameProp + ' ' + _classNameCache[key]
-        : _classNameCache[key] || classNameProp || null;
+      const classNameProp = props[classNamePropKey];
+
+      const classNameForKey = key && _classNameCache[key];
+
+      const className =
+        classNameForKey && classNameProp
+          ? classNameProp + ' ' + classNameForKey
+          : classNameForKey || classNameProp || null;
+
+      const finalProps = { ...styleObj.props };
+      if (className) {
+        finalProps[classNamePropKey] = className;
+      }
+
+      return finalProps;
     },
   };
 

--- a/packages/jsxstyle-utils/src/index.ts
+++ b/packages/jsxstyle-utils/src/index.ts
@@ -6,7 +6,7 @@ export {
 } from './componentStyles';
 export { dangerousStyleValue } from './dangerousStyleValue';
 export { getStyleCache } from './getStyleCache';
-export { getStyleKeysForProps } from './getStyleKeysForProps';
+export { getStyleKeysForProps, ComponentProp } from './getStyleKeysForProps';
 export { pseudoelements, pseudoclasses } from './getStyleKeysForProps';
 export { hyphenateStyleName } from './hyphenateStyleName';
 export { stringHash } from './stringHash';

--- a/packages/jsxstyle-webpack-plugin/src/utils/ast/__tests__/extractStyles.spec.ts
+++ b/packages/jsxstyle-webpack-plugin/src/utils/ast/__tests__/extractStyles.spec.ts
@@ -738,6 +738,22 @@ const blue = \\"blueberry\\";
 "import \\"./ternary-with-classname__jsxstyle.css\\";
 <div className={\\"cool \\" + (dynamic ? \\"_x1\\" : \\"_x2\\") + \\" _x0\\"} />;"
 `);
+
+    expect(rv.css).toMatchInlineSnapshot(`
+"/* ./packages/jsxstyle-webpack-plugin/src/utils/ast/__tests__/mock/ternary-with-classname.js:2 (Block) */
+._x0 {
+  display: block;
+}
+/* ./packages/jsxstyle-webpack-plugin/src/utils/ast/__tests__/mock/ternary-with-classname.js:2 (Block) */
+._x1 {
+  color: red;
+}
+/* ./packages/jsxstyle-webpack-plugin/src/utils/ast/__tests__/mock/ternary-with-classname.js:2 (Block) */
+._x2 {
+  color: blue;
+}
+"
+`);
   });
 
   it('extracts a ternary expression from a component that has a spread operator specified', () => {

--- a/packages/jsxstyle-webpack-plugin/src/utils/ast/extractStaticTernaries.ts
+++ b/packages/jsxstyle-webpack-plugin/src/utils/ast/extractStaticTernaries.ts
@@ -17,6 +17,7 @@ export interface Ternary {
 export function extractStaticTernaries(
   ternaries: Ternary[],
   cacheObject: CacheObject,
+  classNamePropKey: string,
   classNameFormat?: 'hash'
 ): {
   /** styles to be extracted */
@@ -90,11 +91,19 @@ export function extractStaticTernaries(
     .map((key, idx) => {
       const { test, consequentStyles, alternateStyles } = ternariesByKey[key];
       const consequentClassName =
-        getClassNameFromCache(consequentStyles, cacheObject, classNameFormat) ||
-        '';
+        getClassNameFromCache(
+          consequentStyles,
+          cacheObject,
+          classNamePropKey,
+          classNameFormat
+        ) || '';
       const alternateClassName =
-        getClassNameFromCache(alternateStyles, cacheObject, classNameFormat) ||
-        '';
+        getClassNameFromCache(
+          alternateStyles,
+          cacheObject,
+          classNamePropKey,
+          classNameFormat
+        ) || '';
 
       if (!consequentClassName && !alternateClassName) {
         return null;

--- a/packages/jsxstyle-webpack-plugin/src/utils/ast/extractStyles.ts
+++ b/packages/jsxstyle-webpack-plugin/src/utils/ast/extractStyles.ts
@@ -967,6 +967,7 @@ export function extractStyles(
           namedStyleGroups,
           staticAttributes,
           cacheObject,
+          classPropName,
           classNameFormat
         );
 
@@ -989,6 +990,7 @@ export function extractStyles(
           const ternaryObj = extractStaticTernaries(
             staticTernaries,
             cacheObject,
+            classPropName,
             classNameFormat
           );
 
@@ -1111,7 +1113,11 @@ export function extractStyles(
             const styleProps = stylesByClassName[className];
 
             // get object of style objects
-            const styleObjects = getStyleKeysForProps(styleProps, true);
+            const styleObjects = getStyleKeysForProps(
+              styleProps,
+              classPropName,
+              true
+            );
             if (styleObjects == null) {
               continue;
             }

--- a/packages/jsxstyle-webpack-plugin/src/utils/getClassNameFromCache.ts
+++ b/packages/jsxstyle-webpack-plugin/src/utils/getClassNameFromCache.ts
@@ -9,6 +9,7 @@ import type { CacheObject } from '../types';
 export function getClassNameFromCache(
   styleObject: CSSProperties,
   cacheObject: CacheObject,
+  classNamePropKey: string,
   classNameFormat?: 'hash'
 ): string | null {
   if (cacheObject == null) {
@@ -28,12 +29,16 @@ export function getClassNameFromCache(
     return null;
   }
 
-  const styleObjects = getStyleKeysForProps(styleObject);
+  const styleObjects = getStyleKeysForProps(styleObject, classNamePropKey);
   if (!styleObjects) {
     return null;
   }
 
   const classNameKey = styleObjects.classNameKey;
+  if (classNameKey === null) {
+    return null;
+  }
+
   const counterKey: any = Symbol.for('counter');
   cacheObject[counterKey] = cacheObject[counterKey] || 0;
 

--- a/packages/jsxstyle-webpack-plugin/src/utils/getStylesByClassName.ts
+++ b/packages/jsxstyle-webpack-plugin/src/utils/getStylesByClassName.ts
@@ -26,6 +26,7 @@ export function getStylesByClassName(
   namedStyleGroups: Record<string, CSSProperties> = {},
   staticAttributes: Record<string, any>,
   cacheObject: CacheObject,
+  classNamePropKey: string,
   classNameFormat?: 'hash'
 ): StylesByClassName {
   if (typeof staticAttributes !== 'undefined') {
@@ -106,6 +107,7 @@ export function getStylesByClassName(
       const className = getClassNameFromCache(
         styleObject,
         cacheObject,
+        classNamePropKey,
         classNameFormat
       );
       if (!className) {
@@ -131,6 +133,7 @@ export function getStylesByClassName(
     const className = getClassNameFromCache(
       styleProps,
       cacheObject,
+      classNamePropKey,
       classNameFormat
     );
     if (className) {

--- a/packages/jsxstyle/preact/src/index.tsx
+++ b/packages/jsxstyle/preact/src/index.tsx
@@ -49,7 +49,7 @@ function factory(displayName: JsxstyleComponentName): JsxstyleComponent {
     constructor(props: JsxstyleProps<P>) {
       super(props);
       this.component = props.component || tagName;
-      this.className = cache.getClassName(props, props.class);
+      this.calculatedProps = cache.getComponentProps(props, 'class');
     }
 
     public static defaultProps = defaultProps;
@@ -57,18 +57,15 @@ function factory(displayName: JsxstyleComponentName): JsxstyleComponent {
 
     public className: string | null;
     public component: any;
+    private calculatedProps: Record<string, any> | null;
 
     public componentWillReceiveProps(props: JsxstyleProps<P>) {
       this.component = props.component || tagName;
-      this.className = cache.getClassName(props, props.class);
+      this.calculatedProps = cache.getComponentProps(props, 'class');
     }
 
-    public render({ props, style, children }: JsxstyleProps<P>) {
-      return (
-        <this.component {...props} class={this.className} style={style}>
-          {children}
-        </this.component>
-      );
+    public render() {
+      return <this.component {...this.calculatedProps} />;
     }
   };
 }

--- a/packages/jsxstyle/src/__tests__/typescript.spec.ts
+++ b/packages/jsxstyle/src/__tests__/typescript.spec.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as ts from 'typescript';
+import glob from 'glob';
 
 const typecheckFiles = (filenames: string[]): string => {
   const options: ts.CompilerOptions = {
@@ -19,7 +20,10 @@ const typecheckFiles = (filenames: string[]): string => {
 };
 
 it('throws type errors for invalid component/prop types', () => {
-  const demoFile = path.resolve(__dirname, './typescript/demo.tsx');
-  const report = typecheckFiles([demoFile]);
-  expect(report).toMatchInlineSnapshot(`""`);
+  const filePaths = glob.sync('*.tsx', {
+    absolute: true,
+    cwd: path.resolve(__dirname, 'typescript'),
+  });
+  const report = typecheckFiles(filePaths);
+  expect(report).toEqual('');
 });

--- a/packages/jsxstyle/src/__tests__/typescript/demo.tsx
+++ b/packages/jsxstyle/src/__tests__/typescript/demo.tsx
@@ -81,11 +81,21 @@ export const FCWithoutProps = () => (
 export const FCWithStyleProps = () => (
   <>
     <Block component={StyleNumberFC} style={1234} />
-    {/* @ts-expect-error */}
-    <Block component={StyleNumberFC} style={{ width: 1234 }} />
+    <Block
+      component={StyleNumberFC}
+      // @ts-expect-error style is a number
+      style={{ width: 1234 }}
+    />
+    <Block component={StyleNumberFC} style={123} />
     {React.createElement(Block, {
       component: StyleNumberFC,
+      // @ts-expect-error style is a number
       style: 'banana',
+    })}
+    {React.createElement(Block, {
+      component: StyleNumberFC,
+      // @ts-expect-error this appears to be a limitation of createElement typing. Hmmmm.
+      style: 1234,
     })}
     <Block
       component={StyleNeverFC}
@@ -94,7 +104,7 @@ export const FCWithStyleProps = () => (
     />
     <Block
       component={NoStyleFC}
-      // ideally this would be a type error
+      // @ts-expect-error
       style="hmmmm"
     />
   </>

--- a/packages/jsxstyle/src/__tests__/typescript/inline-props.tsx
+++ b/packages/jsxstyle/src/__tests__/typescript/inline-props.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { Block } from 'jsxstyle';
+
+const TestComponent: React.FC<{
+  /** Test comment */
+  value: Record<string, number>;
+}> = () => null;
+
+<Block
+  // @ts-expect-error divs don't accept value props
+  value="ok"
+  color="red"
+/>;
+
+<Block component="input" value="ok" color="red" />;
+
+<Block
+  component="input"
+  // @ts-expect-error inputs don't accept object-type value props
+  value={{}}
+  color="red"
+/>;
+
+<Block component={TestComponent} value={{ hello: 123 }} color="red" />;
+
+<Block
+  component={TestComponent}
+  value={{
+    // @ts-expect-error
+    hello: 'abc',
+  }}
+  color="red"
+/>;
+
+<Block
+  component={TestComponent}
+  // @ts-expect-error value is not a string type
+  value="hello"
+  color="red"
+/>;
+
+// @ts-expect-error value is a required prop
+<Block component={TestComponent} color="red" />;

--- a/packages/jsxstyle/src/componentFactory.ts
+++ b/packages/jsxstyle/src/componentFactory.ts
@@ -19,18 +19,8 @@ export function componentFactory(
     props: React.PropsWithChildren<JsxstyleProps<T>>
   ): React.ReactElement => {
     const Component: any = props.component || tagName;
-    const className = styleCache.getClassName(props, props.className);
-    const componentProps: Record<string, any> = { ...props.props };
-
-    if (className) {
-      componentProps.className = className;
-    }
-
-    if (props.style) {
-      componentProps.style = props.style;
-    }
-
-    return React.createElement(Component, componentProps, props.children);
+    const extractedProps = styleCache.getComponentProps(props);
+    return React.createElement(Component, extractedProps);
   };
 
   component.displayName = displayName;

--- a/packages/jsxstyle/src/types.ts
+++ b/packages/jsxstyle/src/types.ts
@@ -1,4 +1,4 @@
-import { CSSProperties } from 'jsxstyle-utils';
+import { CSSProperties, ComponentProp } from 'jsxstyle-utils';
 
 export type IntrinsicElement = keyof JSX.IntrinsicElements;
 
@@ -34,24 +34,20 @@ export type ExtractProps<T extends ValidComponentPropValue> = T extends
   : {};
 
 /** Props that will be passed through to whatever component is specified */
-export interface StylableComponentProps<T extends ValidComponentPropValue> {
-  /** passed as-is through to the underlying component */
-  className?: string | null | false;
-  /** passed as-is through to the underlying component */
-  style?: ExtractProps<T>['style'] | null | false;
-}
+export type StylableComponentProps<T extends ValidComponentPropValue> = Pick<
+  ExtractProps<T>,
+  Extract<keyof ExtractProps<T>, ComponentProp>
+>;
 
 /** Common props */
-interface SharedProps<T extends ValidComponentPropValue>
-  extends StylableComponentProps<T>,
-    CSSProperties {
+interface SharedProps extends CSSProperties {
   /** An object of media query values keyed by the desired style prop prefix */
   mediaQueries?: Record<string, string>;
 }
 
 /** Props for jsxstyle components that have a `component` prop set */
 interface JsxstylePropsWithComponent<C extends ValidComponentPropValue>
-  extends SharedProps<C> {
+  extends SharedProps {
   /** Component value can be either a React component or a tag name string. Defaults to `div`. */
   component: C;
   /** Object of props that will be passed down to the component specified in the `component` prop */
@@ -59,13 +55,15 @@ interface JsxstylePropsWithComponent<C extends ValidComponentPropValue>
 }
 
 /** Props for jsxstyle components that have no `component` prop set */
-interface JsxstyleDefaultProps extends SharedProps<'div'> {
+interface JsxstyleDefaultProps extends SharedProps {
   /** Component value can be either a React component or a tag name string. Defaults to `div`. */
   component?: undefined;
   /** Object of props that will be passed down to the underlying div */
   props?: JSX.IntrinsicElements['div'];
 }
 
-export type JsxstyleProps<C extends ValidComponentPropValue> =
+export type JsxstyleProps<T extends ValidComponentPropValue = 'div'> = (
   | JsxstyleDefaultProps
-  | JsxstylePropsWithComponent<C>;
+  | JsxstylePropsWithComponent<T>
+) &
+  StylableComponentProps<T>;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -39,7 +39,7 @@ export default [
           [
             require.resolve('./misc/babel-plugin-pure-annotation'),
             {
-              functionNames: ['factory', 'depFactory'],
+              functionNames: ['factory', 'depFactory', 'componentFactory'],
             },
           ],
         ],


### PR DESCRIPTION
Per discussion in https://github.com/jsxstyle/jsxstyle/issues/147#issuecomment-881978246 I’ve added a new feature to `getStyleKeysForProps`. In addition to generating an string of styles, `getStyleKeysForProps` will now also filter out the following common component props:

- checked
- children
- href
- id
- name
- placeholder
- style
- type
- value

The style cache has been updated accordingly. Since there are a few internal breaking changes, `jsxstyle-utils` has been bumped to the next major version.

Runtime implementation has gotten even simpler:

```tsx
const component = <T extends ValidComponentPropValue = 'div'>(
  props: React.PropsWithChildren<JsxstyleProps<T>>
): React.ReactElement => {
  const Component: any = props.component || tagName;
  const extractedProps = styleCache.getComponentProps(props);
  return React.createElement(Component, extractedProps);
};
```