### PR TITLE
Add `processProps` function

### DIFF
--- a/.changeset/processProps.md
+++ b/.changeset/processProps.md
@@ -1,0 +1,5 @@
+---
+'jsxstyle-utils': minor
+---
+
+Added a new exported function to `jsxstyle-utils`, `processProps`, that turns an object of style props and component props into an object of component props and an array of CSS rules. `processProps` powers the “one classname per style prop” functionality introduced in #163.

--- a/__tests__/__snapshots__/meta.spec.ts.snap
+++ b/__tests__/__snapshots__/meta.spec.ts.snap
@@ -61,6 +61,10 @@ jsxstyle-utils
 - lib/jsxstyle-utils.cjs.js
 - lib/jsxstyle-utils.es.js
 - lib/jsxstyle-utils.js
+- lib/parseStyleProps.d.ts
+- lib/parseStyleProps.d.ts.map
+- lib/processProps.d.ts
+- lib/processProps.d.ts.map
 - lib/stringHash.d.ts
 - lib/stringHash.d.ts.map
 - lib/types.d.ts

--- a/packages/jsxstyle-utils/src/__tests__/parseStyleProps.spec.ts
+++ b/packages/jsxstyle-utils/src/__tests__/parseStyleProps.spec.ts
@@ -1,0 +1,231 @@
+import { parseStyleProps, ParsedStyleProp } from '../parseStyleProps';
+
+const formatParsedStyleProps = (
+  value: Record<string, ParsedStyleProp> | null | undefined
+) =>
+  Object.entries(value || {}).reduce<Record<string, any>>(
+    (prev, [k, v]) => ((prev[k] = v.propValue), prev),
+    {}
+  );
+
+describe('parseStyleProps', () => {
+  it('returns null parsedStyleProps when given an empty props object', () => {
+    const results = parseStyleProps({}, 'className');
+    expect(results).toEqual({
+      componentProps: {},
+      parsedStyleProps: {},
+    });
+  });
+
+  it('converts a style object to a style string that only contains valid styles', () => {
+    class Useless {
+      constructor(public stuff: string) {}
+      toString(): string {
+        return this.stuff;
+      }
+    }
+
+    function prototypeTest(stuff: string) {
+      return new Useless(stuff);
+    }
+
+    const { parsedStyleProps } = parseStyleProps(
+      {
+        prop1: 'string',
+        prop2: 1234,
+        prop3: 0,
+        prop4: prototypeTest('wow'),
+        prop5: null,
+        prop6: undefined,
+        prop7: false,
+      },
+      'className'
+    );
+
+    expect(formatParsedStyleProps(parsedStyleProps)).toMatchInlineSnapshot(`
+      Object {
+        "prop1": "string",
+        "prop2": 1234,
+        "prop3": 0,
+        "prop4": Useless {
+          "stuff": "wow",
+        },
+      }
+    `);
+  });
+
+  it('uses classNamePropKey to filter out className prop', () => {
+    const exampleProps = { banana: 'purple', className: 'purple' };
+
+    const { parsedStyleProps: classNameParsedStyleProps } = parseStyleProps(
+      exampleProps,
+      'className'
+    );
+    const { parsedStyleProps: bananaParsedStyleProps } = parseStyleProps(
+      exampleProps,
+      'banana'
+    );
+
+    expect(Object.keys(classNameParsedStyleProps || {})).toEqual(['banana']);
+    expect(Object.keys(bananaParsedStyleProps || {})).toEqual(['className']);
+  });
+
+  it('splits out pseudoelements and pseudoclasses', () => {
+    const { parsedStyleProps } = parseStyleProps(
+      {
+        activeColor: 'purple',
+        hoverColor: 'orange',
+        placeholderColor: 'blue',
+        selectionBackgroundColor: 'red',
+      },
+      'className'
+    );
+
+    expect(formatParsedStyleProps(parsedStyleProps)).toMatchInlineSnapshot(`
+      Object {
+        "backgroundColor::selection": "red",
+        "color::placeholder": "blue",
+        "color:active": "purple",
+        "color:hover": "orange",
+      }
+    `);
+  });
+
+  it('splits out allowlisted props', () => {
+    const { componentProps } = parseStyleProps(
+      {
+        name: 'name prop',
+        id: 'id prop',
+        href: 'https://jsx.style',
+      },
+      'className'
+    );
+
+    expect(componentProps).toMatchInlineSnapshot(`
+      Object {
+        "href": "https://jsx.style",
+        "id": "id prop",
+        "name": "name prop",
+      }
+    `);
+  });
+
+  it('splits out props starting with `on`', () => {
+    const parsedProps = parseStyleProps(
+      {
+        // these props will be passed through as component props
+        onBanana: 'purple',
+        onClick: () => null,
+        onNonExistentEventHandler: 123,
+
+        // this should be considered a style
+        ontological: 456,
+      },
+      'className'
+    );
+
+    expect(parsedProps).toMatchInlineSnapshot(`
+      Object {
+        "componentProps": Object {
+          "onBanana": "purple",
+          "onClick": [Function],
+          "onNonExistentEventHandler": 123,
+        },
+        "parsedStyleProps": Object {
+          "ontological": Object {
+            "propName": "ontological",
+            "propValue": 456,
+            "pseudoclass": undefined,
+            "pseudoelement": undefined,
+            "specificity": 0,
+          },
+        },
+      }
+    `);
+  });
+
+  it('expands horizontal/vertical margin/padding shorthand props', () => {
+    const { parsedStyleProps } = parseStyleProps(
+      {
+        aaa: 123,
+        zzz: 123,
+        margin: 1,
+        marginH: 2,
+        marginLeft: 3,
+      },
+      'className'
+    );
+
+    expect(formatParsedStyleProps(parsedStyleProps)).toMatchInlineSnapshot(`
+      Object {
+        "aaa": 123,
+        "margin": 1,
+        "marginLeft": 3,
+        "marginRight": 2,
+        "zzz": 123,
+      }
+    `);
+  });
+
+  it('supports pseudo-prefixed horizontal/vertical margin/padding shorthand props', () => {
+    const { parsedStyleProps } = parseStyleProps(
+      {
+        margin: 1,
+        marginH: 2,
+        marginLeft: 3,
+        hoverMarginLeft: 4,
+        activeMarginV: 5,
+        placeholderPaddingV: 6,
+        placeholderPadding: 7,
+        placeholderPaddingTop: 8,
+      },
+      'className'
+    );
+
+    expect(formatParsedStyleProps(parsedStyleProps)).toMatchInlineSnapshot(`
+      Object {
+        "margin": 1,
+        "marginBottom:active": 5,
+        "marginLeft": 3,
+        "marginLeft:hover": 4,
+        "marginRight": 2,
+        "marginTop:active": 5,
+        "padding::placeholder": 7,
+        "paddingBottom::placeholder": 6,
+        "paddingTop::placeholder": 8,
+      }
+    `);
+  });
+
+  it('creates different sets of styles for differently ordered props', () => {
+    const { parsedStyleProps: parsedStyleProps1 } = parseStyleProps(
+      {
+        marginH: 1,
+        marginLeft: 2,
+      },
+      'className'
+    );
+
+    const { parsedStyleProps: parsedStyleProps2 } = parseStyleProps(
+      {
+        marginLeft: 2,
+        marginH: 1,
+      },
+      'className'
+    );
+
+    expect(formatParsedStyleProps(parsedStyleProps1)).toMatchInlineSnapshot(`
+      Object {
+        "marginLeft": 2,
+        "marginRight": 1,
+      }
+    `);
+
+    expect(formatParsedStyleProps(parsedStyleProps2)).toMatchInlineSnapshot(`
+      Object {
+        "marginLeft": 1,
+        "marginRight": 1,
+      }
+    `);
+  });
+});

--- a/packages/jsxstyle-utils/src/__tests__/processProps.spec.ts
+++ b/packages/jsxstyle-utils/src/__tests__/processProps.spec.ts
@@ -1,0 +1,363 @@
+import { processProps } from '../processProps';
+
+const createClassNameGetter = () => {
+  let index = -1;
+  const cache: Record<string, number> = {};
+  return (key: string) => {
+    cache[key] = cache[key] || ++index;
+    return '_x' + cache[key];
+  };
+};
+
+describe('processProps', () => {
+  it('returns empty rules and props when given an empty props object', () => {
+    const keyObj = processProps({}, 'className', createClassNameGetter());
+    expect(keyObj).toEqual({
+      props: {},
+      rules: [],
+    });
+  });
+
+  it('converts a style object to a style string that only contains valid styles', () => {
+    class Useless {
+      constructor(public stuff: string) {}
+      toString(): string {
+        return this.stuff;
+      }
+    }
+
+    function prototypeTest(stuff: string) {
+      return new Useless(stuff);
+    }
+
+    const keyObj = processProps(
+      {
+        prop1: 'string',
+        prop2: 1234,
+        prop3: 0,
+        prop4: prototypeTest('wow'),
+        prop5: null,
+        prop6: undefined,
+        prop7: false,
+      },
+      'className',
+      createClassNameGetter()
+    );
+
+    expect(keyObj).toMatchInlineSnapshot(`
+Object {
+  "props": Object {
+    "className": "_x0 _x1 _x2 _x3",
+  },
+  "rules": Array [
+    "._x0 { prop1:string }",
+    "._x1 { prop2:1234px }",
+    "._x2 { prop3:0 }",
+    "._x3 { prop4:wow }",
+  ],
+}
+`);
+  });
+
+  it('uses classNamePropKey to set className prop', () => {
+    const classNameKeyObj = processProps(
+      { color: 'purple' },
+      'className',
+      createClassNameGetter()
+    );
+
+    const bananaKeyObj = processProps(
+      { color: 'purple' },
+      'banana',
+      createClassNameGetter()
+    );
+
+    expect(Object.keys(classNameKeyObj?.props!)).toEqual(['className']);
+    expect(Object.keys(bananaKeyObj?.props!)).toEqual(['banana']);
+  });
+
+  it('splits out pseudoelements and pseudoclasses', () => {
+    const keyObj = processProps(
+      {
+        activeColor: 'purple',
+        hoverColor: 'orange',
+        placeholderColor: 'blue',
+        selectionBackgroundColor: 'red',
+      },
+      'className',
+      createClassNameGetter()
+    );
+
+    expect(keyObj).toMatchInlineSnapshot(`
+Object {
+  "props": Object {
+    "className": "_x0 _x1 _x2 _x3",
+  },
+  "rules": Array [
+    "._x0:active { color:purple }",
+    "._x1:hover { color:orange }",
+    "._x2::placeholder { color:blue }",
+    "._x3._x3::selection { background-color:red }",
+  ],
+}
+`);
+  });
+
+  it('splits out allowlisted props', () => {
+    const keyObj = processProps(
+      {
+        name: 'name prop',
+        id: 'id prop',
+        href: 'https://jsx.style',
+      },
+      'className',
+      createClassNameGetter()
+    );
+
+    expect(keyObj).toMatchInlineSnapshot(`
+Object {
+  "props": Object {
+    "href": "https://jsx.style",
+    "id": "id prop",
+    "name": "name prop",
+  },
+  "rules": Array [],
+}
+`);
+  });
+
+  it('splits out props starting with `on`', () => {
+    const keyObj = processProps(
+      {
+        // these props will be passed through as component props
+        onBanana: 'purple',
+        onClick: () => null,
+        onNonExistentEventHandler: 123,
+
+        // this should be considered a style
+        ontological: 456,
+      },
+      'className',
+      createClassNameGetter()
+    );
+
+    expect(keyObj).toMatchInlineSnapshot(`
+Object {
+  "props": Object {
+    "className": "_x0",
+    "onBanana": "purple",
+    "onClick": [Function],
+    "onNonExistentEventHandler": 123,
+  },
+  "rules": Array [
+    "._x0 { ontological:456px }",
+  ],
+}
+`);
+  });
+
+  it('expands horizontal/vertical margin/padding shorthand props', () => {
+    const keyObj1 = processProps(
+      {
+        margin: 1,
+        marginH: 2,
+        marginLeft: 3,
+      },
+      'className',
+      createClassNameGetter()
+    );
+
+    expect(keyObj1).toMatchInlineSnapshot(`
+Object {
+  "props": Object {
+    "className": "_x0 _x1 _x2",
+  },
+  "rules": Array [
+    "._x0 { margin:1px }",
+    "._x1._x1 { margin-left:3px }",
+    "._x2._x2 { margin-right:2px }",
+  ],
+}
+`);
+  });
+
+  it('supports pseudo-prefixed horizontal/vertical margin/padding shorthand props', () => {
+    const keyObj1 = processProps(
+      {
+        margin: 1,
+        marginH: 2,
+        marginLeft: 3,
+        hoverMarginLeft: 4,
+        activeMarginV: 5,
+        placeholderPaddingV: 6,
+        placeholderPadding: 7,
+        placeholderPaddingTop: 8,
+        placeholderHoverColor: 9,
+      },
+      'className',
+      createClassNameGetter()
+    );
+
+    expect(keyObj1).toMatchInlineSnapshot(`
+Object {
+  "props": Object {
+    "className": "_x0 _x1 _x2 _x3 _x4 _x5 _x6 _x7 _x8 _x9",
+  },
+  "rules": Array [
+    "._x0 { margin:1px }",
+    "._x1._x1 { margin-left:3px }",
+    "._x2._x2 { margin-right:2px }",
+    "._x3._x3:hover { margin-left:4px }",
+    "._x4._x4:active { margin-top:5px }",
+    "._x5._x5:active { margin-bottom:5px }",
+    "._x6._x6::placeholder { padding-top:8px }",
+    "._x7._x7::placeholder { padding-bottom:6px }",
+    "._x8::placeholder { padding:7px }",
+    "._x9:hover::placeholder { color:9px }",
+  ],
+}
+`);
+  });
+
+  it('supports object-type animation syntax', () => {
+    const styleObj = {
+      color: 'red',
+      animation: {
+        from: { opacity: 0 },
+        to: { padding: 123 },
+      },
+    };
+
+    const keyObj = processProps(styleObj, 'className', createClassNameGetter());
+
+    expect(keyObj).toMatchInlineSnapshot(`
+Object {
+  "props": Object {
+    "className": "_x0 _x1",
+  },
+  "rules": Array [
+    "._x0 { color:red }",
+    "@keyframes _x1 { from { opacity:0 } to { padding:123px } }",
+    "._x1._x1 { animation-name:_x1 }",
+  ],
+}
+`);
+  });
+
+  it('does not support pseudo-prefixed props in object-type animation syntax', () => {
+    const styleObj = {
+      color: 'red',
+      animation: {
+        from: { activePadding: 0 },
+        to: { padding: 123 },
+      },
+    };
+
+    const keyObj = processProps(styleObj, 'className', createClassNameGetter());
+
+    expect(keyObj).toMatchInlineSnapshot(`
+Object {
+  "props": Object {
+    "className": "_x0",
+  },
+  "rules": Array [
+    "._x0 { color:red }",
+  ],
+}
+`);
+  });
+
+  it('does not support pseudo-prefixed props in object-type animation syntax', () => {
+    const consoleSpy = jest.spyOn(console, 'error');
+    const styleObj = {
+      color: 'red',
+      animation: {
+        from: { activePadding: 0 },
+        to: { padding: 123 },
+      },
+    };
+
+    const { rules } = processProps(
+      styleObj,
+      'className',
+      createClassNameGetter()
+    );
+
+    expect(consoleSpy).toHaveBeenCalledTimes(1);
+    expect(consoleSpy.mock.calls[0]).toMatchInlineSnapshot(`
+Array [
+  "[jsxstyle] Encountered a pseudo-prefixed prop in animation value: %s%s%s",
+  "padding",
+  "",
+  ":active",
+]
+`);
+
+    expect(rules).toMatchInlineSnapshot(`
+Array [
+  "._x0 { color:red }",
+]
+`);
+    consoleSpy.mockRestore();
+  });
+
+  it('logs an error when it encounters empty/invalid style objects in object-type animation syntax', () => {
+    const consoleSpy = jest.spyOn(console, 'error');
+
+    const { rules: rules1 } = processProps(
+      {
+        color: 'red',
+        animation: {
+          thing1: {},
+          thing2: { padding: 123 },
+        },
+      },
+      'className',
+      createClassNameGetter()
+    );
+
+    const { rules: rules2 } = processProps(
+      {
+        color: 'red',
+        animation: {
+          thing1: { padding: null },
+          thing2: { padding: 123 },
+        },
+      },
+      'className',
+      createClassNameGetter()
+    );
+
+    expect(consoleSpy).toHaveBeenCalledTimes(2);
+    expect(consoleSpy.mock.calls).toMatchInlineSnapshot(`
+Array [
+  Array [
+    "[jsxstyle] Animation value \`%s\` contained no valid style props:",
+    "thing1",
+    Object {},
+  ],
+  Array [
+    "[jsxstyle] Animation value \`%s\` contained no valid style props:",
+    "thing1",
+    Object {
+      "padding": null,
+    },
+  ],
+]
+`);
+
+    expect(rules1).toMatchInlineSnapshot(`
+Array [
+  "._x0 { color:red }",
+]
+`);
+
+    expect(rules2).toMatchInlineSnapshot(`
+Array [
+  "._x0 { color:red }",
+]
+`);
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/packages/jsxstyle-utils/src/index.ts
+++ b/packages/jsxstyle-utils/src/index.ts
@@ -7,6 +7,7 @@ export {
 export { dangerousStyleValue } from './dangerousStyleValue';
 export { getStyleCache } from './getStyleCache';
 export { getStyleKeysForProps, ComponentProp } from './getStyleKeysForProps';
+export { processProps } from './processProps';
 export { pseudoelements, pseudoclasses } from './getStyleKeysForProps';
 export { hyphenateStyleName } from './hyphenateStyleName';
 export { stringHash } from './stringHash';

--- a/packages/jsxstyle-utils/src/parseStyleProps.ts
+++ b/packages/jsxstyle-utils/src/parseStyleProps.ts
@@ -1,0 +1,210 @@
+import type { CSSProperties } from './types';
+
+// global flag makes subsequent calls of capRegex.test advance to the next match
+const capRegex = /[A-Z]/g;
+
+const commonComponentProps = {
+  // class (preact) and className (React) are handled separately
+  checked: true,
+  children: true,
+  href: true,
+  id: true,
+  name: true,
+  placeholder: true,
+  style: true,
+  type: true,
+  value: true,
+};
+
+const pseudoelements = {
+  after: true,
+  before: true,
+  placeholder: true,
+  selection: true,
+};
+
+const pseudoclasses = {
+  active: true,
+  checked: true,
+  disabled: true,
+  empty: true,
+  enabled: true,
+  focus: true,
+  hover: true,
+  invalid: true,
+  link: true,
+  required: true,
+  target: true,
+  valid: true,
+};
+
+/** Props that are used internally and not passed on to the underlying component */
+const skippedProps = {
+  component: true,
+  mediaQueries: true,
+  props: true,
+};
+
+const doubleSpecificityPrefixes = {
+  animation: true,
+  background: true,
+  flex: true,
+  font: true,
+  margin: true,
+  padding: true,
+};
+
+const shorthandProps = {
+  marginH: (margin: CSSProperties['marginLeft']): CSSProperties => ({
+    marginLeft: margin,
+    marginRight: margin,
+  }),
+  marginV: (margin: CSSProperties['marginTop']): CSSProperties => ({
+    marginTop: margin,
+    marginBottom: margin,
+  }),
+  paddingH: (padding: CSSProperties['paddingLeft']): CSSProperties => ({
+    paddingLeft: padding,
+    paddingRight: padding,
+  }),
+  paddingV: (padding: CSSProperties['paddingTop']): CSSProperties => ({
+    paddingTop: padding,
+    paddingBottom: padding,
+  }),
+};
+
+export type ShorthandProp = typeof shorthandProps;
+
+export interface ParsedStyleProp {
+  pseudoelement?: string;
+  pseudoclass?: string;
+  specificity: number;
+  propName: string;
+  propValue: any;
+}
+
+export type ComponentProp = keyof typeof commonComponentProps;
+
+export const parseStyleProps = (
+  props: Record<string, any>,
+  classNamePropKey: string
+): {
+  parsedStyleProps: Record<string, ParsedStyleProp>;
+  componentProps: Record<string, any>;
+} => {
+  let componentProps: Record<string, any> =
+    typeof props.props === 'object' ? { ...props.props } : {};
+
+  const parsedStyleProps: Record<string, ParsedStyleProp> = {};
+  for (const originalPropName in props) {
+    const propValue = props[originalPropName];
+
+    // separate known component props from style props
+    if (commonComponentProps.hasOwnProperty(originalPropName)) {
+      componentProps[originalPropName] = props[originalPropName];
+      continue;
+    }
+
+    if (
+      skippedProps.hasOwnProperty(originalPropName) ||
+      originalPropName === classNamePropKey ||
+      !props.hasOwnProperty(originalPropName)
+    ) {
+      continue;
+    }
+
+    let propName: string = originalPropName;
+    let pseudoelement: string | undefined;
+    let pseudoclass: string | undefined;
+    let specificity = 0;
+
+    capRegex.lastIndex = 0;
+    let splitIndex = 0;
+
+    let propNamePrefix: string | false =
+      capRegex.test(originalPropName) &&
+      capRegex.lastIndex > 1 &&
+      originalPropName.slice(0, capRegex.lastIndex - 1);
+
+    // all /^on[A-Z]/ props get passed through to the underlying component
+    if (propNamePrefix === 'on') {
+      componentProps[originalPropName] = props[originalPropName];
+      continue;
+    }
+
+    // check for pseudoelement prefix
+    if (propNamePrefix && pseudoelements[propNamePrefix]) {
+      pseudoelement = propNamePrefix;
+      splitIndex = capRegex.lastIndex - 1;
+      propNamePrefix =
+        capRegex.test(originalPropName) &&
+        originalPropName[splitIndex].toLowerCase() +
+          originalPropName.slice(splitIndex + 1, capRegex.lastIndex - 1);
+    }
+
+    // check for pseudoclass prefix
+    if (propNamePrefix && pseudoclasses[propNamePrefix]) {
+      pseudoclass = propNamePrefix;
+      splitIndex = capRegex.lastIndex - 1;
+      propNamePrefix =
+        capRegex.test(originalPropName) &&
+        originalPropName[splitIndex].toLowerCase() +
+          originalPropName.slice(splitIndex + 1, capRegex.lastIndex - 1);
+    }
+
+    // check if we need to bump specificity
+    if (propNamePrefix && doubleSpecificityPrefixes[propNamePrefix]) {
+      specificity++;
+    }
+
+    // trim prefixes off propName
+    if (splitIndex > 0) {
+      propName =
+        originalPropName[splitIndex].toLowerCase() +
+        originalPropName.slice(splitIndex + 1);
+    }
+
+    const keySuffix =
+      (pseudoelement ? '::' + pseudoelement : '') +
+      (pseudoclass ? ':' + pseudoclass : '');
+
+    const propFn = shorthandProps[propName];
+    if (typeof propFn === 'function') {
+      const expandedProps = propFn(propValue);
+      if (expandedProps == null || typeof expandedProps !== 'object') {
+        continue;
+      }
+      for (const expandedPropName in expandedProps) {
+        const expandedPropValue = expandedProps[expandedPropName];
+        if (expandedPropValue == null || expandedPropValue === false) {
+          continue;
+        }
+
+        parsedStyleProps[expandedPropName + keySuffix] = {
+          pseudoelement,
+          pseudoclass,
+          specificity,
+          propName: expandedPropName,
+          propValue: expandedPropValue,
+        };
+      }
+    } else {
+      if (propValue == null || propValue === false) {
+        continue;
+      }
+
+      parsedStyleProps[propName + keySuffix] = {
+        pseudoelement,
+        pseudoclass,
+        specificity,
+        propName,
+        propValue,
+      };
+    }
+  }
+
+  return {
+    parsedStyleProps,
+    componentProps,
+  };
+};

--- a/packages/jsxstyle-utils/src/processProps.ts
+++ b/packages/jsxstyle-utils/src/processProps.ts
@@ -1,0 +1,157 @@
+import { dangerousStyleValue } from './dangerousStyleValue';
+import { hyphenateStyleName } from './hyphenateStyleName';
+import { parseStyleProps } from './parseStyleProps';
+
+interface PropsAndRules {
+  /** Filtered props object */
+  props: Record<string, any>;
+  /** An array of CSS rules extracted from style props */
+  rules: string[];
+}
+
+export function processProps(
+  props: Record<string, any>,
+  classNamePropKey: string,
+  getClassNameForKey: (key: string) => string,
+  mediaQuery?: string
+): PropsAndRules {
+  const rules: string[] = [];
+
+  if (props == null || typeof props !== 'object') {
+    return {
+      props: {},
+      rules,
+    };
+  }
+
+  const { parsedStyleProps, componentProps } = parseStyleProps(
+    props,
+    classNamePropKey
+  );
+
+  if (!parsedStyleProps) {
+    return {
+      props: componentProps,
+      rules,
+    };
+  }
+
+  let classNames: string = props[classNamePropKey] || '';
+
+  propLoop: for (const key in parsedStyleProps) {
+    const mergedProp = parsedStyleProps[key];
+    const { pseudoelement, pseudoclass, propName, propValue } = mergedProp;
+
+    let specificity = mergedProp.specificity;
+    let styleValue: any;
+    let className: string;
+    let hyphenatedPropName: string;
+
+    if (mediaQuery) {
+      specificity += 2;
+    }
+
+    if (
+      propName === 'animation' &&
+      propValue &&
+      typeof propValue === 'object'
+    ) {
+      let animationValue = '';
+      for (const k in propValue) {
+        const obj = propValue[k];
+        let groupStyles = '';
+
+        const animationResult = parseStyleProps(obj, 'className');
+
+        for (const key in animationResult.parsedStyleProps) {
+          const {
+            propName,
+            propValue,
+            pseudoclass,
+            pseudoelement,
+          } = animationResult.parsedStyleProps[key];
+          if (pseudoclass || pseudoelement) {
+            if (process.env.NODE_ENV !== 'production') {
+              console.error(
+                '[jsxstyle] Encountered a pseudo-prefixed prop in animation value: %s%s%s',
+                propName,
+                pseudoelement ? '::' + pseudoelement : '',
+                pseudoclass ? ':' + pseudoclass : ''
+              );
+            }
+            continue propLoop;
+          }
+          const value = dangerousStyleValue(propName, propValue);
+          if (value === '') continue;
+          groupStyles +=
+            (groupStyles === '' ? ' ' : '; ') +
+            hyphenateStyleName(propName) +
+            ':' +
+            value;
+        }
+
+        if (groupStyles === '') {
+          if (process.env.NODE_ENV !== 'production') {
+            console.error(
+              '[jsxstyle] Animation value `%s` contained no valid style props:',
+              k,
+              obj
+            );
+          }
+
+          continue propLoop;
+        }
+
+        animationValue += k + ' {' + groupStyles + ' } ';
+      }
+
+      if (animationValue === '') {
+        continue propLoop;
+      }
+
+      const animationKey = getClassNameForKey(animationValue);
+
+      className = animationKey;
+      hyphenatedPropName = 'animation-name';
+      styleValue = animationKey;
+      specificity++;
+
+      rules.push(`@keyframes ${animationKey} { ${animationValue}}`);
+    } else {
+      styleValue = dangerousStyleValue(propName, propValue);
+      if (styleValue === '') continue;
+
+      className = getClassNameForKey(
+        (mediaQuery ? mediaQuery + '~' : '') + key + ':' + styleValue
+      );
+      hyphenatedPropName = hyphenateStyleName(propName);
+    }
+
+    const styleRule =
+      (mediaQuery ? '@media ' + mediaQuery + ' { ' : '') +
+      '.' +
+      className +
+      (specificity > 0 ? '.' + className : '') +
+      (specificity > 1 ? '.' + className : '') +
+      (specificity > 2 ? '.' + className : '') +
+      (specificity > 3 ? '.' + className : '') +
+      (pseudoclass ? ':' + pseudoclass : '') +
+      (pseudoelement ? '::' + pseudoelement : '') +
+      ' { ' +
+      hyphenatedPropName +
+      ':' +
+      styleValue +
+      ' }' +
+      (mediaQuery ? ' }' : '');
+
+    classNames += (classNames === '' ? '' : ' ') + className;
+
+    rules.push(styleRule);
+  }
+
+  if (classNames) {
+    componentProps[classNamePropKey] = classNames;
+  }
+
+  return { props: componentProps, rules };
+}


### PR DESCRIPTION
This PR introduces a new export function to `jsxstyle-utils` named `processProps`. It’s designed to replace `getStyleKeysForProps` and all the code we have to write to make style key objects usable. This is the core internal piece that powers #163.

I have intentionally not reimplemented prefix-based media query support in `processProps`. When integrated into jsxstyle and the webpack plugin, this will introduce a breaking change.