### PR TITLE
Remove IE11 from browserslist

### DIFF
--- a/.changeset/remove IE11 support.md
+++ b/.changeset/remove IE11 support.md
@@ -1,0 +1,5 @@
+---
+'jsxstyle': major
+---
+
+Removed IE11 from the list of supported browsers.

--- a/examples/jsxstyle-react-webpack5-example/webpack.config.js
+++ b/examples/jsxstyle-react-webpack5-example/webpack.config.js
@@ -13,6 +13,8 @@ module.exports = {
     filename: 'bundle.js',
   },
 
+  target: 'web',
+
   plugins: [
     new ReactIndexPlugin(),
     new JsxstyleWebpackPlugin({

--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "singleQuote": true
   },
   "browserslist": [
-    "ie 11",
-    "Firefox ESR",
-    "> 0.5%"
+    "defaults",
+    "not IE 11",
+    "maintained node versions"
   ],
   "dependencies": {
     "@babel/core": "^7.7.4",

--- a/packages/jsxstyle-utils/src/parseStyleProps.ts
+++ b/packages/jsxstyle-utils/src/parseStyleProps.ts
@@ -93,7 +93,7 @@ export const parseStyleProps = (
   componentProps: Record<string, any>;
 } => {
   const componentProps: Record<string, any> =
-    typeof props.props === 'object' ? { ...props.props } : {};
+    typeof props.props === 'object' ? Object.assign({}, props.props) : {};
 
   const parsedStyleProps: Record<string, ParsedStyleProp> = {};
   for (const originalPropName in props) {

--- a/packages/jsxstyle-webpack-plugin/src/thirdparty.d.ts
+++ b/packages/jsxstyle-webpack-plugin/src/thirdparty.d.ts
@@ -1,12 +1,6 @@
-declare module 'webpack/lib/node/NodeWatchFileSystem' {
-  class NodeWatchFileSystem {
-    constructor(fs: import('webpack').InputFileSystem);
-  }
-  export = NodeWatchFileSystem;
-}
-
 declare module 'webpack/lib/LibraryTemplatePlugin';
 declare module 'webpack/lib/LoaderTargetPlugin';
 declare module 'webpack/lib/node/NodeTargetPlugin';
 declare module 'webpack/lib/node/NodeTemplatePlugin';
+declare module 'webpack/lib/node/NodeWatchFileSystem';
 declare module 'webpack/lib/SingleEntryPlugin';


### PR DESCRIPTION
This officially removes IE11 support from jsxstyle. IE11 customers will need to include an `Object.assign` polyfill.