### PR TITLE
Ensure that style rules are only inserted once

### DIFF
--- a/.changeset/memoise insertRuleCallback.md
+++ b/.changeset/memoise insertRuleCallback.md
@@ -1,0 +1,5 @@
+---
+'jsxstyle': minor
+---
+
+Ensured that style rules are only written to the DOM one time.

--- a/__tests__/__snapshots__/meta.spec.ts.snap
+++ b/__tests__/__snapshots__/meta.spec.ts.snap
@@ -5,16 +5,15 @@ exports[`npm publish only publishes the intended files 1`] = `
   "
 gatsby-plugin-jsxstyle
 ======================
-- package.json
+- LICENSE
 - gatsby-node.js
 - gatsby-ssr.js
 - index.js
-- LICENSE
+- package.json
 ",
   "
 jsxstyle
 ========
-- package.json
 - LICENSE
 - README.md
 - lib/base64-loader/base64-loader.cjs.js
@@ -100,6 +99,10 @@ jsxstyle
 - lib/types/webpack-plugin/noop.d.ts.map
 - lib/types/webpack-plugin/plugin.d.ts
 - lib/types/webpack-plugin/plugin.d.ts.map
+- lib/types/webpack-plugin/types.d.ts
+- lib/types/webpack-plugin/types.d.ts.map
+- lib/types/webpack-plugin/utils/ModuleCache.d.ts
+- lib/types/webpack-plugin/utils/ModuleCache.d.ts.map
 - lib/types/webpack-plugin/utils/ast/accessSafe.d.ts
 - lib/types/webpack-plugin/utils/ast/accessSafe.d.ts.map
 - lib/types/webpack-plugin/utils/ast/evaluateAstNode.d.ts
@@ -130,8 +133,6 @@ jsxstyle
 - lib/types/webpack-plugin/utils/getExportsFromModuleSource.d.ts.map
 - lib/types/webpack-plugin/utils/makePromise.d.ts
 - lib/types/webpack-plugin/utils/makePromise.d.ts.map
-- lib/types/webpack-plugin/utils/ModuleCache.d.ts
-- lib/types/webpack-plugin/utils/ModuleCache.d.ts.map
 - lib/types/webpack-plugin/utils/typePredicates.d.ts
 - lib/types/webpack-plugin/utils/typePredicates.d.ts.map
 - lib/types/webpack-plugin/utils/wrapFileSystem.d.ts
@@ -145,6 +146,7 @@ jsxstyle
 - lib/webpack-plugin/webpack-plugin.cjs.js.map
 - lib/webpack-plugin/webpack-plugin.es.js
 - lib/webpack-plugin/webpack-plugin.es.js.map
+- package.json
 - preact/package.json
 - webpack-plugin/package.json
 ",

--- a/__tests__/meta.spec.ts
+++ b/__tests__/meta.spec.ts
@@ -7,23 +7,6 @@ import { getPackages } from '@manypkg/get-packages';
 
 const JSXSTYLE_ROOT = path.resolve(__dirname, '..');
 
-// https://github.com/npm/npm-packlist/commit/63d1e3ee9c2e23ac87496ca78d3183f0652c531c
-const legacySort = (a: string, b: string) =>
-  // extname, then basename, then locale alphabetically
-  a === 'package.json'
-    ? -1
-    : b === 'package.json'
-    ? 1
-    : /^node_modules/.test(a) && !/^node_modules/.test(b)
-    ? 1
-    : /^node_modules/.test(b) && !/^node_modules/.test(a)
-    ? -1
-    : path.dirname(a) === '.' && path.dirname(b) !== '.'
-    ? -1
-    : path.dirname(b) === '.' && path.dirname(a) !== '.'
-    ? 1
-    : a.localeCompare(b);
-
 describe('npm publish', () => {
   it('only publishes the intended files', async () => {
     const packages = await getPackages(JSXSTYLE_ROOT);
@@ -38,7 +21,7 @@ describe('npm publish', () => {
 ${pkg.packageJson.name}
 ${pkg.packageJson.name.replace(/./g, '=')}
 ${fileList
-  .sort(legacySort)
+  .sort()
   .map((fileName) => {
     // chunk filenames contain a hash that will change across builds
     const updatedFileName = fileName.replace(

--- a/packages/jsxstyle/src/utils/createClassNameGetter.ts
+++ b/packages/jsxstyle/src/utils/createClassNameGetter.ts
@@ -1,9 +1,11 @@
+import type { CacheObject } from '../webpack-plugin/types';
+import type { GetClassNameForKeyFn } from './processProps';
 import { stringHash } from './stringHash';
 
 export const createClassNameGetter = (
-  cacheObject: Record<string, any>,
+  cacheObject: CacheObject,
   classNameFormat?: 'hash'
-) => {
+): GetClassNameForKeyFn => {
   let getClassName: (key: string) => string;
 
   if (classNameFormat === 'hash') {
@@ -11,12 +13,14 @@ export const createClassNameGetter = (
     getClassName = (key: string) => '_' + stringHash(key).toString(36);
   } else {
     // incrementing integer
-    const counterKey: any = Symbol.for('counter');
+    const counterKey = Symbol.for('counter');
     cacheObject[counterKey] = cacheObject[counterKey] || 0;
     getClassName = () => '_x' + (cacheObject[counterKey]++).toString(36);
   }
 
-  return (key: string) => {
-    return (cacheObject[key] = cacheObject[key] || getClassName(key));
+  return (key) => {
+    const className = (cacheObject[key] =
+      cacheObject[key] || getClassName(key));
+    return className;
   };
 };

--- a/packages/jsxstyle/src/utils/processProps.ts
+++ b/packages/jsxstyle/src/utils/processProps.ts
@@ -2,10 +2,12 @@ import { dangerousStyleValue } from './dangerousStyleValue';
 import { hyphenateStyleName } from './hyphenateStyleName';
 import { parseStyleProps } from './parseStyleProps';
 
+export type GetClassNameForKeyFn = (key: string) => string;
+
 export function processProps(
   props: Record<string, any>,
   classNamePropKey: string,
-  getClassNameForKey: (key: string) => string,
+  getClassNameForKey: GetClassNameForKeyFn,
   insertRuleCallback?: (rule: string, key: string) => void,
   mediaQuery?: string
 ): Record<string, unknown> | null {
@@ -97,7 +99,7 @@ export function processProps(
       insertRuleCallback &&
         insertRuleCallback(
           `@keyframes ${animationKey} { ${animationValue}}`,
-          animationKey
+          '@' + animationKey
         );
     } else {
       styleValue = dangerousStyleValue(propName, propValue);

--- a/packages/jsxstyle/src/webpack-plugin/types.ts
+++ b/packages/jsxstyle/src/webpack-plugin/types.ts
@@ -1,8 +1,10 @@
-import { UserConfigurableOptions } from './utils/ast/extractStyles';
+import type { UserConfigurableOptions } from './utils/ast/extractStyles';
 import type { Volume } from 'memfs';
+import type { GetClassNameForKeyFn } from '../utils/processProps';
 
 export interface CacheObject {
-  [key: string]: unknown;
+  [key: string]: string;
+  [key: symbol]: number;
 }
 
 export type LoaderOptions = UserConfigurableOptions;
@@ -32,7 +34,7 @@ export interface JsxstyleWebpackPluginOptions extends UserConfigurableOptions {
 export interface PluginContext {
   /** Loader options set by the plugin. These options can overridden on a per-loader basis. */
   defaultLoaderOptions: Partial<LoaderOptions>;
-  getClassNameForKey: (key: string) => string;
+  getClassNameForKey: GetClassNameForKeyFn;
   getModules: () => Promise<Record<string, unknown>>;
   memoryFS: MemoryFS;
 }

--- a/packages/jsxstyle/src/webpack-plugin/utils/ast/extractStaticTernaries.ts
+++ b/packages/jsxstyle/src/webpack-plugin/utils/ast/extractStaticTernaries.ts
@@ -1,7 +1,8 @@
 import generate from '@babel/generator';
 import * as t from '@babel/types';
 import invariant from 'invariant';
-import { CSSProperties, processProps } from '../../../utils';
+import { type CSSProperties, processProps } from '../../../utils';
+import type { GetClassNameForKeyFn } from '../../../utils/processProps';
 
 export interface Ternary {
   name: string;
@@ -12,7 +13,7 @@ export interface Ternary {
 
 export function extractStaticTernaries(
   ternaries: Ternary[],
-  getClassNameForKey: (key: string) => string,
+  getClassNameForKey: GetClassNameForKeyFn,
   onInsertRule: (rule: string, key: string) => void
 ): /** ternaries grouped into one binary expression */
 t.BinaryExpression | t.ConditionalExpression | null {

--- a/packages/jsxstyle/src/webpack-plugin/utils/ast/extractStyles.ts
+++ b/packages/jsxstyle/src/webpack-plugin/utils/ast/extractStyles.ts
@@ -17,6 +17,7 @@ import { getPropValueFromAttributes } from './getPropValueFromAttributes';
 import { getStaticBindingsForScope } from './getStaticBindingsForScope';
 import { parse } from './parse';
 import { getImportForSource } from './getImportForSource';
+import type { GetClassNameForKeyFn } from '../../../utils/processProps';
 
 const validCssModes = [
   'singleInlineImport',
@@ -33,7 +34,7 @@ export interface ExtractStylesOptions {
   errorCallback?: (str: string, ...args: any[]) => void;
   warnCallback?: (str: string, ...args: any[]) => void;
   evaluateVars?: boolean;
-  getClassNameForKey: (key: string) => string;
+  getClassNameForKey: GetClassNameForKeyFn;
   modulesByAbsolutePath?: Record<string, unknown>;
 }
 


### PR DESCRIPTION
If a style rule is already present in the class name cache, the `insertRule` callback will not be called. This is how jsxstyle used to function but I accidentally refactored it out some time ago.